### PR TITLE
Fix existing tests by making relationships bidirectional by default

### DIFF
--- a/includes/Relationships/Relationship.php
+++ b/includes/Relationships/Relationship.php
@@ -73,7 +73,7 @@ abstract class Relationship {
 		$this->name = $name;
 
 		$defaults = array(
-			'is_bidirectional' => false,
+			'is_bidirectional' => true,
 			'from' => array(
 				'enable_ui' => true,
 				'sortable' => false,


### PR DESCRIPTION
When we adopted the library and added support for the `is_bidirectional` argument, the default value was set as `false`. This caused most existing tests to fail because they expected ALL relationships to be bidirectional. By switching the default value for the `is_bidirectional` to `true`, we enable all existing tests to pass successfully.

This change should not cause any issues in Atlas Content Modeler, as the `is_bidirectional` argument in that implementation is already hard coded to `true`.

### Testing

To run the tests from the project root, first run the installation:

(remember to replace `db_user` and `db_pass` with a valid username and password for your local mysql database)
```sh
/bin/bash bin/install-wp-tests.sh acm_content_connect db_user db_pass
```

Then kick off the tests:
```sh
/bin/bash run-tests.sh
```